### PR TITLE
Use weak function for handle_irq_m_ext

### DIFF
--- a/lib/drivers/plic.c
+++ b/lib/drivers/plic.c
@@ -155,7 +155,8 @@ void plic_irq_deregister(plic_irq_t irq)
 }
 
 /*Entry Point for PLIC Interrupt Handler*/
-uintptr_t handle_irq_m_ext(uintptr_t cause, uintptr_t epc)
+uintptr_t __attribute__((weak))
+handle_irq_m_ext(uintptr_t cause, uintptr_t epc)
 {
     /*
      * After the highest-priority pending interrupt is claimed by a target


### PR DESCRIPTION
Using weak function for handle_irq_m_ext, therefore, user can overload it to realize custom interrupt handling.

- [x] I have thoroughly tested my contribution.
- [x] The code I submitted has no copyright issues.
