### PR TITLE
解除CPU时钟获取对freertos头文件的耦合

### DIFF
--- a/lib/drivers/include/sysctl.h
+++ b/lib/drivers/include/sysctl.h
@@ -1025,9 +1025,7 @@ uint32_t sysctl_set_spi0_dvp_data(uint8_t en);
 void sysctl_set_power_mode(sysctl_power_bank_t power_bank, sysctl_io_power_mode_t io_power_mode);
 
 /**
- * @brief       register callback to freq changed
- *
- * @param[in]   callback            callback function point
+ * @brief       get the frequency of CPU
  * 
  * @return      The frequency of CPU
  */

--- a/lib/drivers/include/sysctl.h
+++ b/lib/drivers/include/sysctl.h
@@ -1025,6 +1025,15 @@ uint32_t sysctl_set_spi0_dvp_data(uint8_t en);
 void sysctl_set_power_mode(sysctl_power_bank_t power_bank, sysctl_io_power_mode_t io_power_mode);
 
 /**
+ * @brief       register callback to freq changed
+ *
+ * @param[in]   callback            callback function point
+ * 
+ * @return      The frequency of CPU
+ */
+uint32_t sysctl_cpu_get_freq(void);
+
+/**
  * @brief       Set frequency of CPU
  * @param[in]   freq       The desired frequency in Hz
  *

--- a/lib/drivers/sysctl.c
+++ b/lib/drivers/sysctl.c
@@ -20,7 +20,6 @@
 #include "string.h"
 #include "encoding.h"
 #include "bsp.h"
-#include "portmacro.h"
 
 #define SYSCTRL_CLOCK_FREQ_IN0 (26000000UL)
 
@@ -51,7 +50,6 @@ const uint8_t get_source_aclk[] =
 };
 
 volatile sysctl_t *const sysctl = (volatile sysctl_t *)SYSCTL_BASE_ADDR;
-extern UBaseType_t uxCPUClockRate;
 
 uint32_t sysctl_get_git_id(void)
 {
@@ -1797,14 +1795,20 @@ uint32_t sysctl_pll_set_freq(sysctl_pll_t pll, uint32_t pll_freq)
     return result;
 }
 
+static uint32_t cpu_freq = 390000000;
+
+uint32_t sysctl_cpu_get_freq(void)
+{
+    return cpu_freq;
+}
+
 uint32_t sysctl_cpu_set_freq(uint32_t freq)
 {
     if(freq == 0)
         return 0;
 
-    freq = sysctl_pll_set_freq(SYSCTL_PLL0, (sysctl->clk_sel0.aclk_divider_sel + 1) * 2 * freq);
-    uxCPUClockRate = freq;
-    return freq;
+    cpu_freq = sysctl_pll_set_freq(SYSCTL_PLL0, (sysctl->clk_sel0.aclk_divider_sel + 1) * 2 * freq);
+    return cpu_freq;
 }
 
 void sysctl_enable_irq(void)

--- a/lib/freertos/portable/port.c
+++ b/lib/freertos/portable/port.c
@@ -65,8 +65,6 @@ automatically be set to 0 when the first task is started. */
 static UBaseType_t uxCriticalNesting[portNUM_PROCESSORS] = {[0 ... portNUM_PROCESSORS - 1] = 0xaaaaaaaa};
 PRIVILEGED_DATA static corelock_t xCoreLock = CORELOCK_INIT;
 
-UBaseType_t uxCPUClockRate = 390000000;
-
 /* Contains context when starting scheduler, save all 31 registers */
 #ifdef __gracefulExit
 #error Not ported
@@ -206,5 +204,5 @@ void vPortFatal(const char* file, int line, const char* message)
 
 UBaseType_t uxPortGetCPUClock()
 {
-    return uxCPUClockRate;
+    return (UBaseType_t)sysctl_cpu_get_freq();
 }


### PR DESCRIPTION
Signed-off-by: zyh <lymz@foxmail.com>

Fixes 解除CPU时钟获取对freertos头文件的耦合.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] I have thoroughly tested my contribution.
- [x] The code I submitted has no copyright issues.

目前在sysctl.c中 对freertos porting的头文件portmacro.h存在依赖关系。对于不使用freertos的用户来说这种依赖关系会造成一些麻烦 这份拉取请求中解除掉了这种耦合关系，通过增加时钟获取接口来解决这个问题。
```c
/**
 * @brief       register callback to freq changed
 *
 * @param[in]   callback            callback function point
 * 
 * @return      The frequency of CPU
 */
uint32_t sysctl_cpu_get_freq(void);
```