### PR TITLE
Add interface of get plic instance

### DIFF
--- a/lib/drivers/include/plic.h
+++ b/lib/drivers/include/plic.h
@@ -466,6 +466,13 @@ void plic_irq_deregister(plic_irq_t irq);
  */
 void plic_irq_unregister(plic_irq_t irq);
 
+/**
+ * @brief       Get IRQ table
+ *
+ * @return      the point of IRQ table
+ */
+plic_instance_t * plic_get_instance(void);
+
 /* For c++ compatibility */
 #ifdef __cplusplus
 }

--- a/lib/drivers/plic.c
+++ b/lib/drivers/plic.c
@@ -161,6 +161,11 @@ void plic_irq_unregister(plic_irq_t irq)
 
 void __attribute__((weak, alias("plic_irq_unregister"))) plic_irq_deregister(plic_irq_t irq);
 
+plic_instance_t * plic_get_instance(void)
+{
+    return plic_instance;
+}
+
 /*Entry Point for PLIC Interrupt Handler*/
 uintptr_t __attribute__((weak))
 handle_irq_m_ext(uintptr_t cause, uintptr_t epc)


### PR DESCRIPTION
Signed-off-by: zyh <lymz@foxmail.com>

Fixes 将中断表暴露出来。

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] I have thoroughly tested my contribution.
- [x] The code I submitted has no copyright issues.

sdk中采用每个核管理自己中断的方式来安装/卸载中断。当安装中断和卸载中断在不同核上运行时将出现严重错误，但考虑到无操作系统调度的情况下当前方式又合理。故添加获取中断表方法。在SDK外部可以通过劫持中断入口点的方式自行处理中断。并在需要的情况下将中断派发给SDK，可在不改动SDK的情况下将SDK用于各种操作系统。
