### PR TITLE
fix build error for plic_instance_t

### DIFF
--- a/lib/drivers/include/plic.h
+++ b/lib/drivers/include/plic.h
@@ -263,6 +263,15 @@ typedef struct _plic_pending_bits
 } __attribute__((packed, aligned(4))) plic_pending_bits_t;
 
 /**
+ * @brief       plic callback instance
+ */
+typedef struct _plic_instance_t
+{
+    plic_irq_callback_t callback;
+    void *ctx;
+} plic_instance_t;
+
+/**
  * @brief       Target Interrupt Enables
  *
  *              For each interrupt target, each device’s interrupt can be

--- a/lib/drivers/plic.c
+++ b/lib/drivers/plic.c
@@ -21,12 +21,6 @@
 
 volatile plic_t* const plic = (volatile plic_t*)PLIC_BASE_ADDR;
 
-typedef struct _plic_instance_t
-{
-    plic_irq_callback_t callback;
-    void *ctx;
-} plic_instance_t;
-
 static plic_instance_t plic_instance[PLIC_NUM_CORES][IRQN_MAX];
 
 void plic_init(void)


### PR DESCRIPTION
Fixes last PR case build error

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] I have thoroughly tested my contribution.
- [x] The code I submitted has no copyright issues.

上个PR因为测试环境不同。未发现编译异常。实际上因为结构体`plic_instance_t`定义在plic.c中会导致编译错误。这份PR修复了这个错误。